### PR TITLE
Fix TTS voice clearing bug

### DIFF
--- a/src/features/tts/ttsSlice.js
+++ b/src/features/tts/ttsSlice.js
@@ -16,8 +16,8 @@ export const ttsSlice = createSlice({
     setAvailableVoices: (state, action) => {
       const voices = action.payload;
       state.availableVoices = voices;
-      if (state.voice && !state.availableVoices.some(v => v === state.voice))
-        state.voice = undefined;
+      if (state.currentVoice && !state.availableVoices.some(v => v === state.currentVoice))
+        state.currentVoice = undefined;
     },
     toggleIsPlaying: (state, action) => {
       state.isPlaying = !state.isPlaying;

--- a/src/features/wikipedia/wikipediaSlice.js
+++ b/src/features/wikipedia/wikipediaSlice.js
@@ -153,7 +153,6 @@ export const {
   removePages,
   markAsRead,
   setSearchRadius,
-  updatePageRatings,
   updateCalculatedData,
   updateLastSearch
 } = wikipediaSlice.actions;


### PR DESCRIPTION
## Summary
- fix TTS slice voice clearing when updating available voices
- remove stray `updatePageRatings` export

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6840cb6c470083338073ebcaea40b1a9