### PR TITLE
Refactor shortcut hook location

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ It's possible to run the map on a different device than the computer running the
 
 ## Development
 
-The project now uses [Vite](https://vitejs.dev/) instead of Create React App and is built with **React 19**. Start a development server with:
+The project now uses [Vite](https://vitejs.dev/) instead of Create React App and is built with **React 19**. Make sure to install dependencies first:
+
+```bash
+npm install
+```
+
+Start a development server with:
 
 ```bash
 npm run dev

--- a/src/features/map/MapContent.jsx
+++ b/src/features/map/MapContent.jsx
@@ -9,7 +9,7 @@ import { selectSimdata } from "../simdata/simdataSlice";
 import CourseLine from "./layers/CourseLine";
 import SearchRadiusCircle from "./layers/SearchRadiusCircle";
 import Plane from "./layers/Plane";
-import { useShortcutMappingsEffect } from "../../hooks";
+import { useShortcutMappingsEffect } from "./shortcutHooks";
 
 export default function MapContent() {
   const map = useMap();

--- a/src/features/map/shortcutHooks.js
+++ b/src/features/map/shortcutHooks.js
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import { useMap } from "react-leaflet";
 import { useSelector } from "react-redux";
-import { selectShortcutMappings } from "./features/map/mapSlice";
-import { usePlaybackCallbacks } from "./features/tts/TtsPlayer/hooks";
+import { selectShortcutMappings } from "./mapSlice";
+import { usePlaybackCallbacks } from "../tts/TtsPlayer/hooks";
 
 export function useShortcutMappingsEffect() {
   const shortcutMappings = useSelector(selectShortcutMappings);


### PR DESCRIPTION
## Summary
- move `useShortcutMappingsEffect` to `src/features/map`
- update `MapContent.jsx` import path
- add README note about installing dependencies
- remove old `src/hooks.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840e704b3c883338c3327d96ef79048