### PR TITLE
Add CI workflow and agent guidelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+All agents contributing to this repository must verify their changes by running the following commands before committing:
+
+```
+npm install
+npm run build
+```
+
+These commands ensure that dependencies install correctly and the project builds without errors.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `npm install` and `npm run build`
- document contribution rules for agents

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840fadb55c4833391f247916ee8bbbe